### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ dotnet new -u Popov1024.HttpApi.Template.CSharp
 ## Using
 Make some dir:
 ```
-mkdir my-api-project
-cd my-api-project
+mkdir my_api_project
+cd my_api_project
 ```
 
 Create solution:


### PR DESCRIPTION
use underscore (_) instead of dashes (-) in directory naming to avoid error when running docker-compose command